### PR TITLE
Added Python example for htu21d I2C sensor

### DIFF
--- a/component-library/htu21d-i2c-sensor/README.md
+++ b/component-library/htu21d-i2c-sensor/README.md
@@ -2,4 +2,4 @@
 
 This is a simple sensor that connects to the master device via I2C and can relatively precisely measure both temperature (accuracy 0.3 Celsius) and humidity (accuracy 2%).
 
-The I2C communication is described in the included [datasheet](HTU21D-datasheet.pdf). In the `example_hifive` folder, we provide a simple program in Rust which shows how to read temperature and humidity data from the sensor. 
+The I2C communication is described in the included [datasheet](HTU21D-datasheet.pdf). In the `example_hifive` (Rust) and `example-rpi` (Python) folders, we provide a simple program which shows how to read temperature and humidity data from the sensor.

--- a/component-library/htu21d-i2c-sensor/example-rpi/README.md
+++ b/component-library/htu21d-i2c-sensor/example-rpi/README.md
@@ -1,0 +1,31 @@
+# HTU21D I2C Sensor
+
+This is a Python example code that uses I2C to read temperature and humidity from the HTU21D sensor. This code was tested on `Raspberry Pi 4` model `B`, but in theory should work on any board running Python with I2C interface.
+
+This example is based on [CircuitPython tutorial](https://learn.adafruit.com/adafruit-htu21d-f-temperature-humidity-sensor/python-circuitpython)⹁ which also includes description of wiring for RPI.
+
+Installation requires to enable I2C on RPI and installing respective library:
+
+```
+sudo pip3 install adafruit-circuitpython-htu21d
+```
+
+Then, you can use the installed library to directly read temperature and humidity from the sensor:
+
+```python
+import board
+from adafruit_htu21d import HTU21D
+
+i2c = board.I2C()  # uses board.SCL and board.SDA
+sensor = HTU21D(i2c)
+
+print("Temperature: %0.1f °C" % sensor.temperature)
+print("Humidity: %0.1f %%" % sensor.relative_humidity)
+```
+
+Which should print something like this:
+
+```
+Temperature: 22.0 °C
+Humidity: 48.9 %
+```

--- a/component-library/htu21d-i2c-sensor/example-rpi/read.py
+++ b/component-library/htu21d-i2c-sensor/example-rpi/read.py
@@ -1,0 +1,8 @@
+import board
+from adafruit_htu21d import HTU21D
+
+i2c = board.I2C()  # uses board.SCL and board.SDA
+sensor = HTU21D(i2c)
+
+print("Temperature: %0.1f °C" % sensor.temperature)
+print("Humidity: %0.1f %%" % sensor.relative_humidity)


### PR DESCRIPTION
Added Python example to read temperature and humidity from the HTU21D sensor. As a solution, dedicated library for Python was used as described [here](https://learn.adafruit.com/adafruit-htu21d-f-temperature-humidity-sensor/python-circuitpython).
